### PR TITLE
Update depricated image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-node:0.12.0
+FROM arm32v7/node
 
 ADD src/ /src
 WORKDIR /src


### PR DESCRIPTION
Use the 'official' Node.js images at https://hub.docker.com/r/arm32v7/node/ instead for Raspberry Pi 2 and 3.